### PR TITLE
Adds logging to Error Handling Template

### DIFF
--- a/Connected System Plug-in (CSP) Examples/Error Handling/build.gradle
+++ b/Connected System Plug-in (CSP) Examples/Error Handling/build.gradle
@@ -8,6 +8,7 @@ repositories {
 
 dependencies {
   compileOnly 'com.appian:connected-systems-core:1.2.0'
+  compileOnly 'org.slf4j:slf4j-api:1.7.3'
   implementation 'com.appian:connected-systems-client:1.1.0'
   implementation 'org.apache.httpcomponents:httpclient:4.5.6'
   testImplementation 'com.appian:connected-systems-core:1.2.0'

--- a/Connected System Plug-in (CSP) Examples/Error Handling/src/main/java/com/example/errorhandling/templates/ErrorHandlingIntegrationTemplate.java
+++ b/Connected System Plug-in (CSP) Examples/Error Handling/src/main/java/com/example/errorhandling/templates/ErrorHandlingIntegrationTemplate.java
@@ -21,6 +21,8 @@ import com.appian.connectedsystems.templateframework.sdk.configuration.TextPrope
 import com.appian.connectedsystems.templateframework.sdk.diagnostics.IntegrationDesignerDiagnostic;
 import com.appian.connectedsystems.templateframework.sdk.metadata.IntegrationTemplateRequestPolicy;
 import com.appian.connectedsystems.templateframework.sdk.metadata.IntegrationTemplateType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 // Must provide an integration id. This value need only be unique for this connected system
 @TemplateId(name = "ErrorHandlingIntegrationTemplate")
@@ -46,6 +48,8 @@ public class ErrorHandlingIntegrationTemplate extends SimpleIntegrationTemplate 
 
   public static final String PHONE_NUMBER_KEY = "phoneNumber";
   public static final String HTTP_STATUS_CODE_KEY = "httpStatusCode";
+
+  Logger logger = LoggerFactory.getLogger(ErrorHandlingIntegrationTemplate.class);
 
   @Override
   protected SimpleConfiguration getConfiguration(
@@ -108,6 +112,7 @@ public class ErrorHandlingIntegrationTemplate extends SimpleIntegrationTemplate 
           .withDiagnostic(diagnosticBuilder.build())
           .build();
     } catch (Exception e) {
+      logger.error(e.getMessage(), e);
       integrationErrorBuilder.title("https://www.httpbin.org returns the following exception:");
       integrationErrorBuilder.message(e.getMessage());
       responseDiagnosticsMap.put("Error Response", e.toString());


### PR DESCRIPTION
I noticed that the examples didn't show the best way to add logging to a CSP.  
Ben pointed me to a sample PR in the base product, and this follows that example to add logging to the Error Handling Template.