### PR TITLE
Update the textDetection installation directions

### DIFF
--- a/Component Plug-in (CP) Examples/Client API-Enabled Examples/textDetection/README.md
+++ b/Component Plug-in (CP) Examples/Client API-Enabled Examples/textDetection/README.md
@@ -1,6 +1,12 @@
 ## How to install
+The Component Plug-in and the Connected System Plug-in are packaged in two separate bundles. Installing both requires creating both bundles and then placing both into the plug-in directory separately
+
+#### Installing the Connected System Plug-in
+* Enter the `connectedSystemPlugin` directory
 * Run the gradle JAR task (typically `./gradlew build`)
-* Drop the generated jar (which will be located in `connectedSystemPlugin/build/libs/`) into the plugin directory of your Appian install `<AE_ROOT>/_admin/plugins`
+* Drop the generated jar (which will be located in `build/libs/`) into the plugin directory of your Appian install `<AE_ROOT>/_admin/plugins`
+
+#### Installing the Component Plug-in
 * See https://github.com/appian/integration-sdk-examples/blob/master/Component%20Plug-in%20(CP)%20Examples/README.md for installation instructions for the Component Plug-in
 
 ## Sample interface


### PR DESCRIPTION
* Some people found the installation directions a bit unclear because
we didn't clearly state that the component plug-in and the connected
system plug-in are two separate bundles that are installed separately.
This makes that distinction much more clear.